### PR TITLE
Fixed assigning the constant "saves" in the case that no saves are found in the DB

### DIFF
--- a/commands/slash_commands/utility/counting.js
+++ b/commands/slash_commands/utility/counting.js
@@ -65,11 +65,13 @@ module.exports = {
                         const timeTo = msToHumanTime(timeMath)
 
                         for (const data of results) {
-                            const { saves } = data;
+                            let { saves } = data;
+                            if (saves === undefined) {
+                                saves = 0;
+                            }
+
                             for (const guildData of guildResults) {
                                 const guildSaves = guildData.saves;
-
-                                if (saves === undefined) saves = 0;
 
                                 interaction.reply({
                                     content: `You currently have \`${saves}/2\` saves


### PR DESCRIPTION
The counting game had a constant used for "saves", but in the case that no value was found in the database, the value 0 was being assigned to the constant. Changed this to a "let" to avoid the invalid assignment.